### PR TITLE
Fix issues relating to loading of invalid data from file

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -19,10 +19,10 @@
    <br>6.3. [Grade Feature](#63-grade-feature)
    <br>6.4. [GPA Feature](#64-gpa-feature)
    <br>6.5. [Storage Feature](#65-storage-feature)
-8. [User Stories](#7-user-stories)
-9. [Non-Functional Requirements](#8-non-functional-requirements)
-10. [Glossary](#9-glossary)
-11. [Instructions for manual testing](#10-instructions-for-manual-testing)
+7. [User Stories](#7-user-stories)
+8. [Non-Functional Requirements](#8-non-functional-requirements)
+9. [Glossary](#9-glossary)
+10. [Instructions for manual testing](#10-instructions-for-manual-testing)
 
 
 ## 1. Introduction

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -17,11 +17,12 @@
    <br>6.1. [Edit Feature](#61-edit-feature)
    <br>6.2. [Tag Feature](#62-tag-feature)
    <br>6.3. [Grade Feature](#63-grade-feature)
-   <br>6.2. [GPA Feature](#64-gpa-feature) 
-7. [User Stories](#7-user-stories)
-8. [Non-Functional Requirements](#8-non-functional-requirements)
-9. [Glossary](#9-glossary)
-10. [Instructions for manual testing](#10-instructions-for-manual-testing)
+   <br>6.4. [GPA Feature](#64-gpa-feature)
+   <br>6.5. [Storage Feature](#65-storage-feature)
+8. [User Stories](#7-user-stories)
+9. [Non-Functional Requirements](#8-non-functional-requirements)
+10. [Glossary](#9-glossary)
+11. [Instructions for manual testing](#10-instructions-for-manual-testing)
 
 
 ## 1. Introduction
@@ -257,14 +258,29 @@ Below is the sequence diagram of how the GPA feature works:
 ![Sequence Diagram](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/AY2122S2-CS2113T-T10-3/tp/master/docs/SequenceDiagrams/GPA.puml)
 <br><br><br>
 
-### Storage Feature
+### 6.5. Storage Feature
+
+This component makes use of the [Gson](https://sites.google.com/site/gson/gson-user-guide) library, which can be used to convert Java Objects to and from their JSON representation.
+
 Several type-specific classes exist, each overseeing the storage of a different type of user data:
 
 * `ConfigurationStorage` handles the saving and loading of user preferences. This data is stored in the `data/configuration.json` file.
 * `TaskListStorage` handles the saving and loading of the General Tasks list as an `ArrayList<Task>` instance. This data is stored in the `data/tasks.json` file.
 * `ModuleListStorage` handles the saving and loading of all user-created modules as well as the tasks associated with them as an `ArrayList<Module>` instance. This data is stored in the `data/modules.json` file.
-* `ModuleHappyStorageManager` a singleton object keeps a reference of storage and provides other Components easy and encapsulated access to write and load all kinds of data in Mod Happy.
-  Implementation of JsonStorage applies [Gson](https://sites.google.com/site/gson/gson-user-guide), which is a Java library that can be used to convert Java Objects into their JSON representation and back. The Gson object tasks a specific class to wrap  JSON string to an equivalent Java object, which is why the load method for each class should be implemented independently.
+* `ModHappyStorageManager` keeps a reference of storage and provides other components with easy and encapsulated access to write and load all kinds of data in Mod Happy. 
+
+It is worth noting that `ModuleListStorage` and `TaskListStorage` are implemented separately despite having mostly similar code, as the `gson.fromJson` method takes in the class of the object to be constructed, and `.class` cannot be used with generic types.
+
+After data is loaded from the data file, some verification checks are performed to ensure that the data is valid. The following table details some actions taken by Mod Happy in response to various types of data errors:
+
+| Type of error                                                                                                                                                                                                               | Action taken                                                              |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| Malformed JSON<br>Multiple modules with the same module code<br>Module's `moduleCode` attribute is missing<br>Task's `taskName` attribute is missing<br>Invalid configuration name<br>Illegal or no value for configuration | Loading from the file is aborted.<br>A blank file is loaded in its place. |
+| Module's `modularCredit` attribute is missing or contains illegal value                                                                                                                                                     | The missing value is initialised to `0`.                                  |
+| Module's `moduleGrade` attribute is missing or contains illegal value                                                                                                                                                       | The `moduleGrade` is set to `NOT_ENTERED` (the default value when unset). |
+| Task's `isTaskDone` attribute is missing or contains illegal value                                                                                                                                                          | The missing value is initialised to `false`.                              |
+| Task's `taskDuration` attribute is missing or contains illegal value                                                                                                                                                        | The `taskDuration` is set to `null` (the default value when unset).       |
+
 <br><br><br>
 
 ## 7. User Stories

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -433,11 +433,17 @@ ____________________________________________________________
 ```
 <br>
 
-> 📔 <span style="color:#3333ff">**NOTE:**</span>
+> ⚠ <span style="color:#ffa500">**IMPORTANT:**</span>
 >
 > Only one parameter can be edited per command. You cannot do the following:
 >
 > `edit task 2 -m CS2113T -n "CS2113T Tutorial 1" -d "Draw class diagram"`
+
+> 📔 <span style="color:#3333ff">**NOTE:**</span>
+>
+> You can remove optional parameters from tasks or modules by supplying an empty string (`""`). For example:
+> 
+> `edit task 1 -d ""`
 
 <br>
 

--- a/docs/team/chooyikai.md
+++ b/docs/team/chooyikai.md
@@ -25,8 +25,8 @@ You can view my contributed code [here](https://nus-cs2113-ay2122s2.github.io/tp
   - Significantly rewrote `add`, `exit`, `list` and `mark` commands to comply with the new data classes, after they were changed to be more OOP-compliant. ([#75](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/75))
     - The updated implementation of these commands set the precedent for all future command additions, and this was generally followed by the rest of the team when adding new features.
   - Contributed a significant number of test cases for the parsing of user commands, and refactored some existing ones. ([#86](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/86))
-  - Added input validation to the deserialisation functions used for data loading. ([#175](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/175))
-    - This makes the program inspect and reject invalid user data loaded from the data file instead of blindly trusting anything inside (which could violate some program assumptions if the file was corrupted or modified manually).
+  - Added input validation to the deserialisation functions used for data loading. ([#175](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/175), [#194](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/194))
+    - This makes the program inspect and reject / tweak invalid user data loaded from the data file instead of blindly trusting anything inside (which could violate some program assumptions if the file was corrupted or modified manually).
 
 
 - **Documentation:**

--- a/docs/team/chooyikai.md
+++ b/docs/team/chooyikai.md
@@ -36,9 +36,10 @@ You can view my contributed code [here](https://nus-cs2113-ay2122s2.github.io/tp
     - Added accepted inputs for each parameter in each command format. ([#116](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/116))
     - Generally rewrote command explanations to sound less clinical and more friendly.
   - Developer guide:
-    - Added explanation of the Data component and created the relevant class diagrams within that section. (, [#111](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/111))
+    - Added explanation of the Data component and created the relevant class diagrams within that section. ([#111](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/111))
     - Edited explanations of the Parser and Command components. ([#111](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/111))
     - Edited class diagram for the Storage component to correctly represent binding relationships. ([#111](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/111), [#116](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/116))
+    - Added some elaboration for the Storage implementation. ([#194](https://github.com/AY2122S2-CS2113T-T10-3/tp/pull/194))
 
 
 - **Team tasks:**

--- a/src/main/java/seedu/duke/data/Module.java
+++ b/src/main/java/seedu/duke/data/Module.java
@@ -1,6 +1,7 @@
 package seedu.duke.data;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import seedu.duke.util.Grades;
 import seedu.duke.util.StringConstants;
@@ -40,7 +41,11 @@ public class Module {
     }
 
     public void setModuleDescription(String description) {
-        this.moduleDescription = description;
+        if (!Objects.isNull(description) && !description.isBlank()) {
+            this.moduleDescription = description;
+        } else {
+            this.moduleDescription = null;
+        }
     }
 
     public String getModuleDescription() {

--- a/src/main/java/seedu/duke/data/Task.java
+++ b/src/main/java/seedu/duke/data/Task.java
@@ -61,7 +61,7 @@ public class Task {
     }
 
     public void setTaskDescription(String description) {
-        if (description.isBlank()) {
+        if (Objects.isNull(description) || description.isBlank()) {
             taskDescription = null;
         } else {
             taskDescription = description;

--- a/src/main/java/seedu/duke/data/Task.java
+++ b/src/main/java/seedu/duke/data/Task.java
@@ -49,22 +49,33 @@ public class Task {
         return taskDescription;
     }
 
-    public String getWorkingTime() {
+    public String getWorkingTimeString() {
         if (Objects.isNull(workingTime)) {
             return null;
         } else {
             return workingTime.toString();
         }
+    }
 
+    public TaskDuration getWorkingTime() {
+        return workingTime;
     }
 
     public void setTaskDescription(String description) {
-        taskDescription = description;
+        if (description.isBlank()) {
+            taskDescription = null;
+        } else {
+            taskDescription = description;
+        }
     }
 
     //@@author Ch40gRv1-Mu
     public void setWorkingTime(String workingTime) throws ModHappyException {
-        this.workingTime = new TaskDuration(workingTime);
+        if (Objects.isNull(workingTime)) {
+            this.workingTime = null;
+        } else {
+            this.workingTime = new TaskDuration(workingTime);
+        }
     }
 
     public void setTaskName(String taskName) {

--- a/src/main/java/seedu/duke/data/TaskDuration.java
+++ b/src/main/java/seedu/duke/data/TaskDuration.java
@@ -69,7 +69,6 @@ public class TaskDuration {
         throw new WrongDurationFormatException();
     }
 
-
     private HashMap<String, String> parseDurationString(String durationString) throws ModHappyException {
         Pattern commandPattern = Pattern.compile(DURATION_STRING_FORMAT);
         Matcher matcher = commandPattern.matcher(durationString.trim());
@@ -82,6 +81,9 @@ public class TaskDuration {
         return parserDurationString;
     }
 
+    public Duration getTaskDuration() {
+        return taskDuration;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/duke/data/TaskList.java
+++ b/src/main/java/seedu/duke/data/TaskList.java
@@ -86,7 +86,7 @@ public class TaskList {
         return task;
     }
 
-    //@author chooyikai
+    //@@author chooyikai
     public void setList(ArrayList<Task> list) {
         taskList = list;
     }

--- a/src/main/java/seedu/duke/exceptions/InvalidConfigurationException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidConfigurationException.java
@@ -2,6 +2,7 @@ package seedu.duke.exceptions;
 
 import seedu.duke.util.StringConstants;
 
+//@@author chooyikai
 public class InvalidConfigurationException extends ModHappyException {
     public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_CONFIGURATION;
 

--- a/src/main/java/seedu/duke/exceptions/InvalidConfigurationException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidConfigurationException.java
@@ -1,0 +1,11 @@
+package seedu.duke.exceptions;
+
+import seedu.duke.util.StringConstants;
+
+public class InvalidConfigurationException extends ModHappyException {
+    public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_CONFIGURATION;
+
+    public InvalidConfigurationException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/InvalidConfigurationValueException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidConfigurationValueException.java
@@ -1,0 +1,12 @@
+package seedu.duke.exceptions;
+
+import seedu.duke.util.Configuration;
+import seedu.duke.util.StringConstants;
+
+public class InvalidConfigurationValueException extends ModHappyException {
+    public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_CONFIG_VALUE;
+
+    public InvalidConfigurationValueException(Configuration.ConfigurationGroup group, String value) {
+        super(String.format(ERROR_MESSAGE, group, value));
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/InvalidConfigurationValueException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidConfigurationValueException.java
@@ -3,6 +3,7 @@ package seedu.duke.exceptions;
 import seedu.duke.util.Configuration;
 import seedu.duke.util.StringConstants;
 
+//@@author chooyikai
 public class InvalidConfigurationValueException extends ModHappyException {
     public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_CONFIG_VALUE;
 

--- a/src/main/java/seedu/duke/exceptions/InvalidModuleCreditsException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidModuleCreditsException.java
@@ -1,0 +1,12 @@
+package seedu.duke.exceptions;
+
+import seedu.duke.util.StringConstants;
+
+//@@author chooyikai
+public class InvalidModuleCreditsException extends ModHappyException {
+    public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_MODULE_CREDITS;
+
+    public InvalidModuleCreditsException(String moduleCode, int modularCredits) {
+        super(String.format(ERROR_MESSAGE, moduleCode, modularCredits));
+    }
+}

--- a/src/main/java/seedu/duke/exceptions/InvalidModuleException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidModuleException.java
@@ -2,11 +2,10 @@ package seedu.duke.exceptions;
 
 import seedu.duke.util.StringConstants;
 
-//@@author chooyikai
 public class InvalidModuleException extends ModHappyException {
     public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_MODULE;
 
-    public InvalidModuleException(String moduleCode, int modularCredits) {
-        super(String.format(ERROR_MESSAGE, moduleCode, modularCredits));
+    public InvalidModuleException() {
+        super(ERROR_MESSAGE);
     }
 }

--- a/src/main/java/seedu/duke/exceptions/InvalidModuleException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidModuleException.java
@@ -2,6 +2,7 @@ package seedu.duke.exceptions;
 
 import seedu.duke.util.StringConstants;
 
+//@@author chooyikai
 public class InvalidModuleException extends ModHappyException {
     public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_MODULE;
 

--- a/src/main/java/seedu/duke/exceptions/InvalidTaskException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidTaskException.java
@@ -2,6 +2,7 @@ package seedu.duke.exceptions;
 
 import seedu.duke.util.StringConstants;
 
+//@@author chooyikai
 public class InvalidTaskException extends ModHappyException {
     public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_TASK_DATA;
 

--- a/src/main/java/seedu/duke/exceptions/InvalidTaskException.java
+++ b/src/main/java/seedu/duke/exceptions/InvalidTaskException.java
@@ -1,0 +1,11 @@
+package seedu.duke.exceptions;
+
+import seedu.duke.util.StringConstants;
+
+public class InvalidTaskException extends ModHappyException {
+    public static final String ERROR_MESSAGE = StringConstants.ERROR_INVALID_TASK_DATA;
+
+    public InvalidTaskException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/seedu/duke/storage/ConfigurationStorage.java
+++ b/src/main/java/seedu/duke/storage/ConfigurationStorage.java
@@ -29,10 +29,9 @@ public class ConfigurationStorage extends JsonStorage<Configuration> {
     public Configuration loadData(String path) throws ModHappyException {
         Gson gson = new GsonBuilder().create();
         Path file = new File(path).toPath();
-        Configuration configuration;
         try {
             Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8);
-            configuration = gson.fromJson(reader, (Type) Configuration.class);
+            return gson.fromJson(reader, (Type) Configuration.class);
         } catch (JsonSyntaxException e) {
             throw new ReadException();
         } catch (JsonParseException | IOException e) {
@@ -40,15 +39,5 @@ public class ConfigurationStorage extends JsonStorage<Configuration> {
         } catch (Exception e) {
             throw new UnknownException(e.toString());
         }
-        HashMap<Configuration.ConfigurationGroup,String> configMap = configuration.configurationGroupHashMap;
-        for (Configuration.ConfigurationGroup key : configMap.keySet()) {
-            if (key == null) {
-                throw new InvalidConfigurationException();
-            }
-            if (!Configuration.LEGAL_VALUES.get(key).contains(configMap.get(key))) {
-                throw new InvalidConfigurationValueException(key, configMap.get(key));
-            }
-        }
-        return configuration;
     }
 }

--- a/src/main/java/seedu/duke/storage/ModHappyStorageManager.java
+++ b/src/main/java/seedu/duke/storage/ModHappyStorageManager.java
@@ -8,10 +8,16 @@ import java.util.Objects;
 import seedu.duke.data.Module;
 import seedu.duke.data.ModuleList;
 import seedu.duke.data.Task;
-import seedu.duke.data.TaskList;
-import seedu.duke.exceptions.*;
+import seedu.duke.exceptions.DuplicateModuleException;
+import seedu.duke.exceptions.InvalidConfigurationException;
+import seedu.duke.exceptions.InvalidConfigurationValueException;
+import seedu.duke.exceptions.InvalidModuleCreditsException;
+import seedu.duke.exceptions.InvalidModuleException;
+import seedu.duke.exceptions.InvalidTaskException;
+import seedu.duke.exceptions.ModHappyException;
 import seedu.duke.ui.TextUi;
 import seedu.duke.util.Configuration;
+import seedu.duke.util.Grades;
 import seedu.duke.util.StringConstants;
 
 import static seedu.duke.util.NumberConstants.MAXIMUM_MODULAR_CREDITS;
@@ -136,6 +142,9 @@ public class ModHappyStorageManager {
                 for (Module m : arrayListModule) {
                     if (Objects.isNull(m.getModuleCode())) {
                         throw new InvalidModuleException();
+                    }
+                    if (Objects.isNull(m.getModuleGrade())) {
+                        m.setModuleGrade(Grades.NOT_ENTERED.toString());
                     }
                     if (moduleCodes.contains(m.getModuleCode())) {
                         throw new DuplicateModuleException(m.getModuleCode());

--- a/src/main/java/seedu/duke/storage/ModuleListStorage.java
+++ b/src/main/java/seedu/duke/storage/ModuleListStorage.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 
 import seedu.duke.exceptions.ModHappyException;
 import seedu.duke.exceptions.ReadException;
@@ -50,8 +49,6 @@ public class ModuleListStorage extends ListStorage<Module> {
                 arrayList = new ArrayList<>();
             }
 
-        } catch (JsonSyntaxException e) {
-            throw new ReadException(MODIFIED_JSON_EXCEPTION);
         } catch (JsonParseException e) {
             throw new ReadException(MODIFIED_JSON_EXCEPTION);
         } catch (IOException e) {

--- a/src/main/java/seedu/duke/storage/ModuleListStorage.java
+++ b/src/main/java/seedu/duke/storage/ModuleListStorage.java
@@ -48,7 +48,6 @@ public class ModuleListStorage extends ListStorage<Module> {
             } else {
                 arrayList = new ArrayList<>();
             }
-
         } catch (JsonParseException e) {
             throw new ReadException(MODIFIED_JSON_EXCEPTION);
         } catch (IOException e) {

--- a/src/main/java/seedu/duke/storage/TaskListStorage.java
+++ b/src/main/java/seedu/duke/storage/TaskListStorage.java
@@ -14,7 +14,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 import seedu.duke.exceptions.ModHappyException;
 import seedu.duke.exceptions.ReadException;
 import seedu.duke.data.Task;
@@ -49,8 +48,6 @@ public class TaskListStorage extends ListStorage<Task> {
             }
             return arrayList;
 
-        } catch (JsonSyntaxException e) {
-            throw new ReadException(MODIFIED_JSON_EXCEPTION);
         } catch (JsonParseException e) {
             throw new ReadException(MODIFIED_JSON_EXCEPTION);
         } catch (IOException e) {

--- a/src/main/java/seedu/duke/util/StringConstants.java
+++ b/src/main/java/seedu/duke/util/StringConstants.java
@@ -226,14 +226,17 @@ public class StringConstants {
     public static final String ERROR_WRONG_DURATION_FORMAT = "Sorry, the estimated time is in the wrong format ._.";
     public static final String ERROR_DUPLICATE_MODULE = "Multiple modules with module code \"%s\" found. "
             + "Aborting load...";
-    public static final String ERROR_INVALID_MODULE = "Invalid module credits found (%s had %d MCs). Aborting load...";
+    public static final String ERROR_INVALID_MODULE_CREDITS = "Invalid module credits found (%s had %d MCs). "
+            + "Aborting load...";
+    public static final String ERROR_INVALID_MODULE = "Invalid module data found. Aborting load...";
     public static final String ERROR_CATCH_UNKNOWN_EXCEPTION = "Oops, I caught an exception that I wasn't expecting "
             + "0_0:\n%s";
     public static final String MODIFIED_JSON_EXCEPTION = "\nSomething went wrong trying to read the JSON save data.\n"
             + "Has it been manually modified? >:(";
-    public static final String ERROR_INVALID_CONFIGURATION = "Invalid config found in loaded config data.\n"
+    public static final String ERROR_INVALID_CONFIGURATION = "Invalid config found in loaded config data. "
             + "Aborting load...";
     public static final String ERROR_INVALID_CONFIG_VALUE = "Config \"%s\" has illegal value \"%s\". Aborting load...";
+    public static final String ERROR_INVALID_TASK_DATA = "Invalid task data found in loaded data. Aborting load...";
 
 
     /**

--- a/src/main/java/seedu/duke/util/StringConstants.java
+++ b/src/main/java/seedu/duke/util/StringConstants.java
@@ -231,7 +231,9 @@ public class StringConstants {
             + "0_0:\n%s";
     public static final String MODIFIED_JSON_EXCEPTION = "\nSomething went wrong trying to read the JSON save data.\n"
             + "Has it been manually modified? >:(";
-
+    public static final String ERROR_INVALID_CONFIGURATION = "Invalid config found in loaded config data.\n"
+            + "Aborting load...";
+    public static final String ERROR_INVALID_CONFIG_VALUE = "Config \"%s\" has illegal value \"%s\". Aborting load...";
 
 
     /**

--- a/src/test/java/seedu/duke/parsers/ModHappyParserTest.java
+++ b/src/test/java/seedu/duke/parsers/ModHappyParserTest.java
@@ -108,7 +108,7 @@ public class ModHappyParserTest {
             assertNull(((AddCommand) c).getNewModule());
             assertEquals("/t/t/t/t-d-d-d-d-d -d/t/t-d-d-d-d -d-d-d", t.getTaskName());
             assertNull(t.getTaskDescription());
-            assertNull(t.getWorkingTime());
+            assertNull(t.getWorkingTimeString());
             assertNull(((AddCommand) c).getTargetModuleName());
         } catch (Exception e) {
             fail();
@@ -127,7 +127,7 @@ public class ModHappyParserTest {
             assertNull(((AddCommand) c).getNewModule());
             assertEquals("/t/t/t/t-d-d-d-d-d -d/t/t-d-d-d-d -d-d-d", t.getTaskName());
             assertEquals("-d-d-d /t /m -d -d", t.getTaskDescription());
-            assertNull(t.getWorkingTime());
+            assertNull(t.getWorkingTimeString());
             assertNull(((AddCommand) c).getTargetModuleName());
         } catch (Exception e) {
             fail();
@@ -250,7 +250,7 @@ public class ModHappyParserTest {
             assertNull(((AddCommand) c).getNewModule());
             assertEquals("/t/t/t/t-d-d-d-d-d -d/t/t-d-d-d-d -d-d-d", t.getTaskName());
             assertNull(t.getTaskDescription());
-            assertNull(t.getWorkingTime());
+            assertNull(t.getWorkingTimeString());
             assertEquals("cs2113t", ((AddCommand) c).getTargetModuleName());
         } catch (Exception e) {
             fail();
@@ -268,7 +268,7 @@ public class ModHappyParserTest {
             assertNull(((AddCommand) c).getNewModule());
             assertEquals("/t/t/t/t-d", t.getTaskName());
             assertEquals("-d-d-d /t /m -d -d", t.getTaskDescription());
-            assertNull(t.getWorkingTime());
+            assertNull(t.getWorkingTimeString());
             assertEquals("cs2113t", ((AddCommand) c).getTargetModuleName());
         } catch (Exception e) {
             fail();
@@ -288,7 +288,7 @@ public class ModHappyParserTest {
             assertNull(((AddCommand) c).getNewModule());
             assertEquals("/t/t/t/t-d", t.getTaskName());
             assertEquals("-d-d-t-m /m -m -d -t", t.getTaskDescription());
-            assertEquals("1 hour(s) 15 minute(s)", t.getWorkingTime());
+            assertEquals("1 hour(s) 15 minute(s)", t.getWorkingTimeString());
             assertEquals("cs2113t", ((AddCommand) c).getTargetModuleName());
         } catch (Exception e) {
             fail();

--- a/src/test/java/seedu/duke/storage/ModuleListStorageTest.java
+++ b/src/test/java/seedu/duke/storage/ModuleListStorageTest.java
@@ -89,8 +89,8 @@ public class ModuleListStorageTest {
                 for (int j = 0; j < taskList1.getSize(); j++) {
                     assertEquals(taskList1.getTask(j).getTaskName(), taskList2.getTask(j).getTaskName());
                     assertEquals(taskList1.getTask(j).getTaskDescription(), taskList2.getTask(j).getTaskDescription());
-                    assertEquals(taskList1.getTask(j).getWorkingTime(),
-                            taskList2.getTask(j).getWorkingTime());
+                    assertEquals(taskList1.getTask(j).getWorkingTimeString(),
+                            taskList2.getTask(j).getWorkingTimeString());
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/seedu/duke/storage/TaskListStorageTest.java
+++ b/src/test/java/seedu/duke/storage/TaskListStorageTest.java
@@ -51,7 +51,7 @@ public class TaskListStorageTest {
             for (int i = 0; i < list.size(); i++) {
                 assertEquals(list.get(i).getTaskName(), taskList.get(i).getTaskName());
                 assertEquals(list.get(i).getTaskDescription(), taskList.get(i).getTaskDescription());
-                assertEquals(list.get(i).getWorkingTime(), taskList.get(i).getWorkingTime());
+                assertEquals(list.get(i).getWorkingTimeString(), taskList.get(i).getWorkingTimeString());
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
List of fixes:
1) Attempting to load a Module with null moduleCode or Task with null taskName will abort loading from that file.
2) Attempting to load a Task with 0 or negative taskDuration will set it to null.
3) Attempting to load a Module with null grade will set it to NOT_ENTERED.
4) Attempting to load a config file containing invalid config options will abort loading of settings.

Things to note:
- If a boolean gets corrupted in the save file, it defaults to false. (isTaskDone)
- If an integer gets corrupted in the save file, it defaults to 0. (module credits)

I don't think there's any way we can intercept these because the GSON library does not raise any errors if the JSON is still valid, even if the keys are wrong.